### PR TITLE
Autoload fixture matchs

### DIFF
--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -1,3 +1,6 @@
+
+
+
 var teams = [];
 var rankings = {};
 
@@ -17,15 +20,13 @@ var load = function (data) {
         $('#standings').append($('<tr class="ranking"><td>' + r.position + '</td><td></td><td>' + r.name + '</td><td>' + r.ranking.toFixed(2) + '</td><td></td></tr>'));
     });
     $('#right').css('margin-left', $('#left').width());
+
+    loadFixture();
+
     $('#loading').hide();
     $('#left').show();
     $('#right').show();
 
-    addFixture();
-    addFixture();
-    addFixture();
-    addFixture();
-    addFixture();
 };
 
 var addFixture = function () {
@@ -121,3 +122,72 @@ var calculate = function () {
     });
     $('#right').css('margin-left', $('#left').width());
 }
+
+
+
+loadFixture = function(  ) {
+    var now  = new Date();
+    var from = formatDate( now );
+    var to   =  formatDate( now.addDays( 7 ) );
+
+/*
+var now = new Date();
+var nextWeek = new Date(now);
+nextWeek.setDate(nextWeek.getDate() + 7);
+*/
+
+    var url = "http://cmsapi.pulselive.com/rugby/match?startDate="+from+"&endDate="+to+"&sort=asc&pageSize=100";
+
+    $.get( url ).done( function( data ) {
+
+        $.each(data.content, function (i, e) {
+
+            // MRU ( maybe ) is only for MENS
+            if( e.events[0].sport == 'mru' ) {
+
+                // test if both Country into TEAMS array
+                if( $.inArray( e.teams[0].name, teams ) != -1 && $.inArray( e.teams[1].name, teams ) != -1 ) {
+
+                    addFixture();
+
+                    // home INPUT
+                    $('#fixtures TR:last TD:nth(0) INPUT').val( e.teams[0].name );
+
+                    // home SELECT
+                    $('#fixtures TR:last TD:nth(0) SELECT').val( e.teams[0].name );
+
+                    // away INPUT
+                    $('#fixtures TR:last TD:nth(3) INPUT').val( e.teams[1].name );
+
+                    // away SELECT
+                    $('#fixtures TR:last TD:nth(3) SELECT').val( e.teams[1].name );
+                }
+            }
+        });
+
+        addFixture();
+
+    });
+
+}
+
+
+var formatDate = function(date) {
+    var d     = new Date(date),
+        month = '' + (d.getMonth() + 1),
+        day   = '' + d.getDate(),
+        year  = d.getFullYear();
+
+    return [year, month, day].join('-');
+}
+
+
+Date.prototype.addDays = function (d) {
+    if (d) {
+        var t = this.getTime();
+        t = t + (d * 86400000);
+        this.setTime(t);
+    }
+    return this;
+};
+


### PR DESCRIPTION
(Translated by Google)

Using your same idea, to get the ranking, I captured matches the next 7 days.

Then I discard women's matches.
I assure that countries already exist in the array "teams" to avoid teams like "Barbarians" which does not exist in the ranking

And I finally adding lines (addFixture ()) and setting the countries in the INPUT and SELECT.

Perhaps, in this JSON received also reach youth matches or otherwise, that will have to detect and discard.