### PR TITLE
Add rows showing possible rankings effects of a match

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,23 +66,29 @@
             <div id="fixtures">
                 <table>
                     <thead>
-                        <tr><th colspan="2">Home team</th><th colspan="3">Score</th><th colspan="2">Away team</th><th title='No Home Advantage'>NHA</th><th title='Is Rugby World Cup match'>RWC</th></tr>
+                        <tr>
+                            <th colspan="2">Home team</th>
+                            <th colspan="4">Score</th>
+                            <th colspan="2">Away team</th>
+                            <th title='No Home Advantage'>NHA</th>
+                            <th title='Is Rugby World Cup match'>RWC</th>
+                            <th></th>
+                    </tr>
                     </thead>
                     <!-- ko foreach: fixtures -->
                     <tbody class="fixture">
                         <!-- ko if: $data.venueName || $data.kickoff || $data.liveScoreMode -->
                         <tr class="details">
                             <td class="details-left" colspan="2" data-bind="text: kickoff" title="Kickoff in your browser time"></td>
-                            <td class="details-center" colspan="3" data-bind="text: liveScoreMode"></td>
-                            <td class="details-right" colspan="7" data-bind="text: venueName"></td>
+                            <td class="details-center" colspan="4" data-bind="text: liveScoreMode"></td>
+                            <td class="details-right" colspan="5" data-bind="text: venueName"></td>
                         </tr>
                         <!-- /ko -->
                         <tr class="teams">
-                            <td colspan="2"><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: homeId, optionsCaption: 'Home...', disabled: alreadyInRankings"></select></td colspan="2">
-                            <td><input type="number" min="0" data-bind="value: homeScore, disabled: alreadyInRankings" /></td>
-                            <td style="text-align: center">v</td>
-                            <td><input type="number" min="0" data-bind="value: awayScore, disabled: alreadyInRankings" /></td colspan="5">
-                            <td colspan="2"><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: 'Away...', disabled: alreadyInRankings"></select></td colspan="2">
+                            <td colspan="2" style="text-align: left"><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: homeId, optionsCaption: 'Home...', disabled: alreadyInRankings"></select></td colspan="2">
+                            <td colspan="2" style="text-align: right"><input type="number" min="0" data-bind="value: homeScore, disabled: alreadyInRankings" /></td colspan="2">
+                            <td colspan="2" style="text-align: left"><input type="number" min="0" data-bind="value: awayScore, disabled: alreadyInRankings" /></td colspan="5">
+                            <td colspan="2" style="text-align: right"><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: 'Away...', disabled: alreadyInRankings"></select></td colspan="2">
                             <td>
                                 <input type="checkbox" data-bind="checked: noHome, disabled: alreadyInRankings" />
                                 <span data-bind="if: switched" title="Home team is nominally Away">*</span>
@@ -94,9 +100,9 @@
                         <tr class="possible-changes">
                             <td class="details-left" data-bind="text: $data.homeRankingBefore() ? $data.homeRankingBefore().toFixed(2) : ''"></td>
                             <td class="details-right" data-bind="text: $data.getDisplayChange(0), style: { 'font-weight': $data.activeChange() == 0 ?  'bold' : 'inherit'}"></td class="details-center">
-                            <td class="details-left" data-bind="text: $data.getDisplayChange(1), style: { 'font-weight': $data.activeChange() == 1 ?  'bold' : 'inherit'}"></td class="details-center">
-                            <td class="details-center" data-bind="text: $data.getDisplayChange(2), style: { 'font-weight': $data.activeChange() == 2 ?  'bold' : 'inherit'}"></td class="details-center">
-                            <td class="details-right" data-bind="text: $data.getDisplayChange(3), style: { 'font-weight': $data.activeChange() == 3 ?  'bold' : 'inherit'}"></td class="details-center">
+                            <td class="details-center" data-bind="text: $data.getDisplayChange(1), style: { 'font-weight': $data.activeChange() == 1 ?  'bold' : 'inherit'}"></td class="details-center">
+                            <td colspan="2" class="details-center" data-bind="text: $data.getDisplayChange(2), style: { 'font-weight': $data.activeChange() == 2 ?  'bold' : 'inherit'}"></td class="details-center">
+                            <td class="details-center" data-bind="text: $data.getDisplayChange(3), style: { 'font-weight': $data.activeChange() == 3 ?  'bold' : 'inherit'}"></td class="details-center">
                             <td class="details-left" data-bind="text: $data.getDisplayChange(4), style: { 'font-weight': $data.activeChange() == 4 ?  'bold' : 'inherit'}"></td class="details-center">
                             <td class="details-right" data-bind="text: $data.awayRankingBefore() ? $data.awayRankingBefore().toFixed(2) : ''"></td>
                             <td colspan="3"></td>
@@ -104,12 +110,35 @@
                         <!-- /ko -->
                         <!-- ko if: alreadyInRankings -->
                         <tr class="possible-changes">
-                            <td colspan="7" class="details-center" title="The match is complete and kicked off 90 minutes or more before the latest rankings, so assume it is already included">Already ranked*</td>
+                            <td colspan="8" class="details-center" title="The match is complete and kicked off 90 minutes or more before the latest rankings, so assume it is already included">Already ranked*</td>
                             <td colspan="3"></td>
                         </tr>
                         <!-- /ko -->
                     </tbody>
                     <!-- /ko -->
+                    <!--
+                        trying to be clever and align the score cells like
+                        | HOME | AWAY |
+                        | <1 | 0 | 1> |
+                        by making this 2+2 and 1+2+1
+                        but Chrome seems to not want to align like this if no row has 4 cells there
+                        so we have to make an empty row with this many cells
+                    -->
+                    <tfoot aria-hidden="true">
+                        <tr>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                    </tfoot>
                 </table>
             </div>
             <div id="addrow">

--- a/index.html
+++ b/index.html
@@ -99,11 +99,11 @@
                         <!-- ko if: $data.hasValidTeams() && !$data.alreadyInRankings -->
                         <tr class="possible-changes">
                             <td class="details-left" data-bind="text: $data.homeRankingBefore() ? $data.homeRankingBefore().toFixed(2) : ''"></td>
-                            <td class="details-right" data-bind="text: $data.getDisplayChange(0), style: { 'font-weight': $data.activeChange() == 0 ?  'bold' : 'inherit'}"></td class="details-center">
-                            <td class="details-center" data-bind="text: $data.getDisplayChange(1), style: { 'font-weight': $data.activeChange() == 1 ?  'bold' : 'inherit'}"></td class="details-center">
-                            <td colspan="2" class="details-center" data-bind="text: $data.getDisplayChange(2), style: { 'font-weight': $data.activeChange() == 2 ?  'bold' : 'inherit'}"></td class="details-center">
-                            <td class="details-center" data-bind="text: $data.getDisplayChange(3), style: { 'font-weight': $data.activeChange() == 3 ?  'bold' : 'inherit'}"></td class="details-center">
-                            <td class="details-left" data-bind="text: $data.getDisplayChange(4), style: { 'font-weight': $data.activeChange() == 4 ?  'bold' : 'inherit'}"></td class="details-center">
+                            <td class="details-right" data-bind="text: $data.getDisplayChange(0), style: { 'text-decoration': $data.activeChange() == 0 ?  'underline' : 'inherit'}"></td class="details-center">
+                            <td class="details-center" data-bind="text: $data.getDisplayChange(1), style: { 'text-decoration': $data.activeChange() == 1 ?  'underline' : 'inherit'}"></td class="details-center">
+                            <td colspan="2" class="details-center" data-bind="text: $data.getDisplayChange(2), style: { 'text-decoration': $data.activeChange() == 2 ?  'underline' : 'inherit'}"></td class="details-center">
+                            <td class="details-center" data-bind="text: $data.getDisplayChange(3), style: { 'text-decoration': $data.activeChange() == 3 ?  'underline' : 'inherit'}"></td class="details-center">
+                            <td class="details-left" data-bind="text: $data.getDisplayChange(4), style: { 'text-decoration': $data.activeChange() == 4 ?  'underline' : 'inherit'}"></td class="details-center">
                             <td class="details-right" data-bind="text: $data.awayRankingBefore() ? $data.awayRankingBefore().toFixed(2) : ''"></td>
                             <td colspan="3"></td>
                         </tr>

--- a/index.html
+++ b/index.html
@@ -66,14 +66,22 @@
             <div id="fixtures">
                 <table>
                     <thead>
-                        <tr><th>Home team</th><th colspan='2'>Score</th><th>Away team</th><th title='No Home Advantage'>NHA</th><th title='Is Rugby World Cup match'>RWC</th></tr>
+                        <tr><th>Home team</th><th colspan="5">Score</th><th>Away team</th><th title='No Home Advantage'>NHA</th><th title='Is Rugby World Cup match'>RWC</th></tr>
                     </thead>
-                    <tbody data-bind="foreach: fixtures">
-                        <tr data-bind="if: $index() > 0" class="spacer" aria-hidden=true><!-- only way to get whitespace between rows? --></tr>
-                        <tr>
+                    <!-- ko foreach: fixtures -->
+                    <tbody class="fixture">
+                        <!-- ko if: $data.venueName || $data.kickoff || $data.liveScoreMode -->
+                        <tr class="details">
+                            <td class="details-left" colspan="1" data-bind="text: kickoff" title="Kickoff in your browser time"></td>
+                            <td class="details-center" colspan="5" data-bind="text: liveScoreMode, title: liveScoreExplanation"></td>
+                            <td class="details-right" colspan="5" data-bind="text: venueName"></td>
+                        </tr>
+                        <!-- /ko -->
+                        <tr class="teams">
                             <td><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: homeId, optionsCaption: 'Home...', disabled: alreadyInRankings"></select></td>
-                            <td><input type="number" min="0" data-bind="value: homeScore, disabled: alreadyInRankings" /></td>
-                            <td><input type="number" min="0" data-bind="value: awayScore, disabled: alreadyInRankings" /></td>
+                            <td colspan="2" style="text-align: left"><input type="number" min="0" data-bind="value: homeScore, disabled: alreadyInRankings" /></td>
+                            <td style="text-align: center">v</td>
+                            <td colspan="2" style="text-align: right"><input type="number" min="0" data-bind="value: awayScore, disabled: alreadyInRankings" /></td colspan="5">
                             <td><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: 'Away...', disabled: alreadyInRankings"></select></td>
                             <td>
                                 <input type="checkbox" data-bind="checked: noHome, disabled: alreadyInRankings" />
@@ -82,12 +90,19 @@
                             <td><input type="checkbox" data-bind="checked: isRwc, disabled: alreadyInRankings" /></td>
                             <td><button data-bind="click: function () { $parent.fixtures.remove($data); }, disabled: alreadyInRankings">x</button></td>
                         </tr>
-                        <tr class="details" data-bind="if: $data.venueName || $data.kickoff || $data.liveScoreMode">
-                            <td class="details-left" colspan="1" data-bind="text: kickoff" title="Kickoff in your browser time"></td>
-                            <td class="details-center" colspan="2" data-bind="text: liveScoreMode, title: liveScoreExplanation"></td>
-                            <td class="details-right" colspan="5" data-bind="text: venueName"></td>
+                        <!-- ko if: $data.hasValidTeams() && !$data.alreadyInRankings -->
+                        <tr class="possible-changes">
+                            <td class="details-left" data-bind="text: $data.homeRankingBefore() ? $data.homeRankingBefore().toFixed(2) : ''"></td>
+                            <td class="details-left" data-bind="text: $data.getDisplayChange(0), style: { 'font-weight': $data.activeChange() == 0 ?  'bold' : 'inherit'}"></td class="details-center">
+                            <td class="details-left" data-bind="text: $data.getDisplayChange(1), style: { 'font-weight': $data.activeChange() == 1 ?  'bold' : 'inherit'}"></td class="details-center">
+                            <td class="details-center" data-bind="text: $data.getDisplayChange(2), style: { 'font-weight': $data.activeChange() == 2 ?  'bold' : 'inherit'}"></td class="details-center">
+                            <td class="details-right" data-bind="text: $data.getDisplayChange(3), style: { 'font-weight': $data.activeChange() == 3 ?  'bold' : 'inherit'}"></td class="details-center">
+                            <td class="details-right" data-bind="text: $data.getDisplayChange(4), style: { 'font-weight': $data.activeChange() == 4 ?  'bold' : 'inherit'}"></td class="details-center">
+                            <td class="details-right" data-bind="text: $data.awayRankingBefore() ? $data.awayRankingBefore().toFixed(2) : ''"></td>
                         </tr>
+                        <!-- /ko -->
                     </tbody>
+                    <!-- /ko -->
                 </table>
             </div>
             <div id="addrow">

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                         <!-- ko if: $data.venueName || $data.kickoff || $data.liveScoreMode -->
                         <tr class="details">
                             <td class="details-left" colspan="1" data-bind="text: kickoff" title="Kickoff in your browser time"></td>
-                            <td class="details-center" colspan="5" data-bind="text: liveScoreMode, title: liveScoreExplanation"></td>
+                            <td class="details-center" colspan="5" data-bind="text: liveScoreMode"></td>
                             <td class="details-right" colspan="5" data-bind="text: venueName"></td>
                         </tr>
                         <!-- /ko -->
@@ -99,6 +99,13 @@
                             <td class="details-right" data-bind="text: $data.getDisplayChange(3), style: { 'font-weight': $data.activeChange() == 3 ?  'bold' : 'inherit'}"></td class="details-center">
                             <td class="details-right" data-bind="text: $data.getDisplayChange(4), style: { 'font-weight': $data.activeChange() == 4 ?  'bold' : 'inherit'}"></td class="details-center">
                             <td class="details-right" data-bind="text: $data.awayRankingBefore() ? $data.awayRankingBefore().toFixed(2) : ''"></td>
+                            <td colspan="3"></td>
+                        </tr>
+                        <!-- /ko -->
+                        <!-- ko if: alreadyInRankings -->
+                        <tr class="possible-changes">
+                            <td colspan="7" class="details-center" title="The match is complete and kicked off 90 minutes or more before the latest rankings, so assume it is already included">Already ranked*</td>
+                            <td colspan="3"></td>
                         </tr>
                         <!-- /ko -->
                     </tbody>

--- a/index.html
+++ b/index.html
@@ -66,23 +66,23 @@
             <div id="fixtures">
                 <table>
                     <thead>
-                        <tr><th>Home team</th><th colspan="5">Score</th><th>Away team</th><th title='No Home Advantage'>NHA</th><th title='Is Rugby World Cup match'>RWC</th></tr>
+                        <tr><th colspan="2">Home team</th><th colspan="3">Score</th><th colspan="2">Away team</th><th title='No Home Advantage'>NHA</th><th title='Is Rugby World Cup match'>RWC</th></tr>
                     </thead>
                     <!-- ko foreach: fixtures -->
                     <tbody class="fixture">
                         <!-- ko if: $data.venueName || $data.kickoff || $data.liveScoreMode -->
                         <tr class="details">
-                            <td class="details-left" colspan="1" data-bind="text: kickoff" title="Kickoff in your browser time"></td>
-                            <td class="details-center" colspan="5" data-bind="text: liveScoreMode"></td>
-                            <td class="details-right" colspan="5" data-bind="text: venueName"></td>
+                            <td class="details-left" colspan="2" data-bind="text: kickoff" title="Kickoff in your browser time"></td>
+                            <td class="details-center" colspan="3" data-bind="text: liveScoreMode"></td>
+                            <td class="details-right" colspan="7" data-bind="text: venueName"></td>
                         </tr>
                         <!-- /ko -->
                         <tr class="teams">
-                            <td><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: homeId, optionsCaption: 'Home...', disabled: alreadyInRankings"></select></td>
-                            <td colspan="2" style="text-align: left"><input type="number" min="0" data-bind="value: homeScore, disabled: alreadyInRankings" /></td>
+                            <td colspan="2"><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: homeId, optionsCaption: 'Home...', disabled: alreadyInRankings"></select></td colspan="2">
+                            <td><input type="number" min="0" data-bind="value: homeScore, disabled: alreadyInRankings" /></td>
                             <td style="text-align: center">v</td>
-                            <td colspan="2" style="text-align: right"><input type="number" min="0" data-bind="value: awayScore, disabled: alreadyInRankings" /></td colspan="5">
-                            <td><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: 'Away...', disabled: alreadyInRankings"></select></td>
+                            <td><input type="number" min="0" data-bind="value: awayScore, disabled: alreadyInRankings" /></td colspan="5">
+                            <td colspan="2"><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: 'Away...', disabled: alreadyInRankings"></select></td colspan="2">
                             <td>
                                 <input type="checkbox" data-bind="checked: noHome, disabled: alreadyInRankings" />
                                 <span data-bind="if: switched" title="Home team is nominally Away">*</span>
@@ -93,11 +93,11 @@
                         <!-- ko if: $data.hasValidTeams() && !$data.alreadyInRankings -->
                         <tr class="possible-changes">
                             <td class="details-left" data-bind="text: $data.homeRankingBefore() ? $data.homeRankingBefore().toFixed(2) : ''"></td>
-                            <td class="details-left" data-bind="text: $data.getDisplayChange(0), style: { 'font-weight': $data.activeChange() == 0 ?  'bold' : 'inherit'}"></td class="details-center">
+                            <td class="details-right" data-bind="text: $data.getDisplayChange(0), style: { 'font-weight': $data.activeChange() == 0 ?  'bold' : 'inherit'}"></td class="details-center">
                             <td class="details-left" data-bind="text: $data.getDisplayChange(1), style: { 'font-weight': $data.activeChange() == 1 ?  'bold' : 'inherit'}"></td class="details-center">
                             <td class="details-center" data-bind="text: $data.getDisplayChange(2), style: { 'font-weight': $data.activeChange() == 2 ?  'bold' : 'inherit'}"></td class="details-center">
                             <td class="details-right" data-bind="text: $data.getDisplayChange(3), style: { 'font-weight': $data.activeChange() == 3 ?  'bold' : 'inherit'}"></td class="details-center">
-                            <td class="details-right" data-bind="text: $data.getDisplayChange(4), style: { 'font-weight': $data.activeChange() == 4 ?  'bold' : 'inherit'}"></td class="details-center">
+                            <td class="details-left" data-bind="text: $data.getDisplayChange(4), style: { 'font-weight': $data.activeChange() == 4 ?  'bold' : 'inherit'}"></td class="details-center">
                             <td class="details-right" data-bind="text: $data.awayRankingBefore() ? $data.awayRankingBefore().toFixed(2) : ''"></td>
                             <td colspan="3"></td>
                         </tr>

--- a/scripts/models/FixtureViewModel.js
+++ b/scripts/models/FixtureViewModel.js
@@ -14,7 +14,6 @@ var FixtureViewModel = function (parent) {
     this.liveScoreMode = null;
     this.kickoff = null;
     this.alreadyInRankings = false;
-    this.liveScoreExplanation = null;
 
     this.noHome = ko.observable();
     this.switched = ko.observable();

--- a/scripts/models/FixtureViewModel.js
+++ b/scripts/models/FixtureViewModel.js
@@ -7,6 +7,9 @@ var FixtureViewModel = function (parent) {
     this.homeScore = ko.observable();
     this.awayScore = ko.observable();
 
+    this.homeRankingBefore = ko.observable();
+    this.awayRankingBefore = ko.observable();
+
     this.venueName = null;
     this.liveScoreMode = null;
     this.kickoff = null;
@@ -17,52 +20,80 @@ var FixtureViewModel = function (parent) {
     this.switched = ko.observable();
     this.isRwc = ko.observable();
 
-    this.isValid = ko.computed(function() {
+    this.hasValidTeams = ko.computed(function () {
         var rankings = parent.rankingsById();
-
         var home = rankings[this.homeId()];
         var away = rankings[this.awayId()];
+        return home && away && home != away;
+    }, this);
+
+    this.isValid = ko.computed(function() {
         var homeScore = parseInt(this.homeScore());
         var awayScore = parseInt(this.awayScore());
 
-        return home &&
-            away &&
-            home != away &&
+        return this.hasValidTeams() &&
             !isNaN(homeScore) &&
             !isNaN(awayScore);
     }, this);
 
-    this.winner = ko.computed(function () {
-        if (!this.isValid()) {
-            return null;
+    this.changes = ko.computed(function () {
+        var noHome = this.noHome();
+        var switched = this.switched();
+
+        // Calculate the effective ranking of the "home" team depending on whether
+        // it is really at home, or at a neutral venue, or even if the home team
+        // is nominally away.
+        var homeRanking = this.homeRankingBefore();
+        if (!noHome) {
+            if (!switched) {
+                homeRanking = homeRanking + 3;
+            } else {
+                homeRanking = homeRanking - 3;
+            }
         }
 
-        var homeScore = parseInt(this.homeScore());
-        var awayScore = parseInt(this.awayScore());
+        // Calculate the ranking diff and cap it at 10 points.
+        var rankingDiff = this.awayRankingBefore() - homeRanking; // home is higher = home loss, away is higher = away loss
+        var cappedDiff = Math.min(10, Math.max(-10, rankingDiff));
 
-        if (homeScore > awayScore) return 1;
-        if (awayScore > homeScore) return -1;
-        return 0;
+        // A draw gives the home team one tenth of the diff.
+        var drawChange = cappedDiff / 10;
+
+        var rwcMult = this.isRwc() ? 2 : 1;
+        return [
+            rwcMult * 1.5 * (drawChange + 1),
+            rwcMult * (drawChange + 1),
+            rwcMult * drawChange,
+            rwcMult * (drawChange - 1),
+            rwcMult * 1.5 * (drawChange - 1)
+        ];
     }, this);
 
-    this.multiplier = ko.computed(function() {
+    this.getDisplayChange = function(index) {
+        var changes = this.changes();
+        if (!changes) return null;
+        var change = changes[index];
+
+        var formattedChange = Math.abs(change).toFixed(2);
+        var prefix = change > 0 ? '⮜' : '';
+        var suffix = change < 0 ? '⮞' : '';
+
+        return prefix + formattedChange + suffix;
+    };
+
+    this.activeChange = ko.computed(function () {
         if (!this.isValid()) {
             return null;
         }
 
-        var multiplier = 1;
-
         var homeScore = parseInt(this.homeScore());
         var awayScore = parseInt(this.awayScore());
-        if (homeScore > awayScore + 15 || awayScore > homeScore + 15) {
-            multiplier *= 1.5;
-        }
 
-        if (this.isRwc()) {
-            multiplier *= 2;
-        }
-
-        return multiplier;
+        if (homeScore > awayScore + 15) return 0;
+        if (homeScore > awayScore) return 1;
+        if (awayScore > homeScore + 15) return 4;
+        if (awayScore > homeScore) return 3;
+        return 2;
     }, this);
 
     return this;

--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -193,6 +193,7 @@ var loadFixtures = function(rankings, specifiedDate) {
                     case 'UP': fixture.liveScoreMode = 'Postponed'; break;
                     case 'CC': fixture.liveScoreMode = 'Cancelled'; break;
                     case 'C': {
+                        fixture.liveScoreMode = 'Complete';
                         // WR started publishing rankings on match days during the world cup.
                         // Try to work out if the match is already included in the rankings.
                         // We know it is "complete" because we're in that case.
@@ -208,10 +209,6 @@ var loadFixtures = function(rankings, specifiedDate) {
                         var endMillis = kickoffMillis + 90 * 60 * 1000;
                         if (endMillis < viewModel.originalMillis) {
                             fixture.alreadyInRankings = true;
-                            fixture.liveScoreMode = 'Complete & ranked*';
-                            fixture.liveScoreExplanation = 'The match is complete and kicked off 90 minutes or more before the latest rankings, so assume it is already included';
-                        } else {
-                            fixture.liveScoreMode = 'Complete';
                         }
                         break;
                     }

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -304,11 +304,7 @@ body {
             margin-bottom: (56px / 2) + 2px;
         }
 
-        tr.spacer {
-            height: 3px;
-        }
-
-        tr.details td {
+        tr.details td, tr.possible-changes td {
             font-size: 9px;
             &.details-left {
                 text-align: left;
@@ -322,7 +318,11 @@ body {
         }
 
         th, td {
-            padding: 2px 4px;
+            padding: 0 4px;
+        }
+
+        tbody.fixture tr:first-child td {
+            padding-top: 10px;
         }
 
         th {
@@ -330,7 +330,7 @@ body {
         }
 
         input[type=number] {
-            width: 3em;
+            width: 4em;
         }
     }
 }

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -330,7 +330,7 @@ body {
         }
 
         input[type=number] {
-            width: 4em;
+            width: 3em;
         }
     }
 }


### PR DESCRIPTION
- move the ranking calculation into the fixture itself (as a list of possibilities, and an active possibility based on the score)
- feed each fixture with the current rankings based on previous fixtures, in case a team appears twice
- render the current rankings and possible changes in a row below the teams/scores[^1]
- move the fixture details row above the teams/scores
- move the "this match is already in the rankings" back below the scores, returning the match status to just "Complete"
- figure out why we needed spacer rows and remove them

[^1]: This uses odd colspanning to get a center-aligned "draw" delta without a gap between the score inputs, and Chrome starts having layout issues. May be time to move to a CSS table or flex or something.