### PR TITLE
Include "switched" flag in featurestring and improve format

### DIFF
--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -116,7 +116,7 @@ var ViewModel = function (isFemale) {
     this.fixturesString = ko.pureComputed({
         read: function () {
             return '2:' + $.map(this.fixtures(), function (e) {
-                // In theory we should exclude matches that are already in the rankings, because otherwise we will include thema second time.
+                // In theory we should exclude matches that are already in the rankings, because otherwise we will include them a second time.
                 // But in practice, when we ask for "today's" rankings, we will get the previous rankings, as "today's" rankings were posted after midnight.
                 // These matches, played on top of the previous rankings, should reconstruct the same end result..
                 //if (e.alreadyInRankings) return null;

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -115,7 +115,7 @@ var ViewModel = function (isFemale) {
     // A string representing the selected fixtures and results.
     this.fixturesString = ko.pureComputed({
         read: function () {
-            return '1:' + $.map(this.fixtures(), function (e) {
+            return '2:' + $.map(this.fixtures(), function (e) {
                 if (e.alreadyInRankings) return null;
                 var vars = [];
                 if (e.homeId()) vars[0] = e.homeId();
@@ -124,6 +124,7 @@ var ViewModel = function (isFemale) {
                 if (!isNaN(e.awayScore())) vars[3] = e.awayScore();
                 if (e.noHome()) vars[4] = '1';
                 if (e.isRwc()) vars[5] = '1';
+                if (e.switched()) vars[6] = '1';
 
                 return vars.join(',');
             }).join(';');
@@ -144,6 +145,25 @@ var ViewModel = function (isFemale) {
                         fixture.awayScore(rs[3]);
                         fixture.noHome(rs[4]);
                         fixture.isRwc(rs[5]);
+                        fixture.switched(false);
+                        fs.push(fixture);
+                    });
+                    this.fixtures(fs);
+                    break;
+                case '2':
+                    var fs = [];
+                    var r = this.rankingsById();
+                    var me = this;
+                    $.each(versionAndString[1].split(';'), function (i, e) {
+                        var rs = e.split(',');
+                        var fixture = new FixtureViewModel(me);
+                        fixture.homeId(rs[0]);
+                        fixture.awayId(rs[1]);
+                        fixture.homeScore(rs[2]);
+                        fixture.awayScore(rs[3]);
+                        fixture.noHome(rs[4]);
+                        fixture.isRwc(rs[5]);
+                        fixture.switched(rs[6]);
                         fs.push(fixture);
                     });
                     this.fixtures(fs);

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -116,7 +116,10 @@ var ViewModel = function (isFemale) {
     this.fixturesString = ko.pureComputed({
         read: function () {
             return '2:' + $.map(this.fixtures(), function (e) {
-                if (e.alreadyInRankings) return null;
+                // In theory we should exclude matches that are already in the rankings, because otherwise we will include thema second time.
+                // But in practice, when we ask for "today's" rankings, we will get the previous rankings, as "today's" rankings were posted after midnight.
+                // These matches, played on top of the previous rankings, should reconstruct the same end result..
+                //if (e.alreadyInRankings) return null;
 
                 var t = (e.homeId() || e.awayId()) ? ('t' + (e.homeId() ?? '') + 'v' + (e.awayId() ?? '')) : '';
                 var s = (!isNaN(e.homeScore()) || !isNaN(e.awayScore())) ? ('s' + (!isNaN(e.homeScore()) ? e.homeScore() : '') + '-' + (!isNaN(e.awayScore()) ? e.awayScore() : '')) : '';

--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -136,11 +136,11 @@ var loadFixtures = function(rankings, specifiedDate) {
                     fixture.venueName = [e.venue.name, e.venue.city, e.venue.country].join(', ');
                     anyQueries = true;
                     venueQueries++;
-                    $.get('//cmsapi.pulselive.com/rugby/team/' + e.teams[0].id).done(function(teamData) {
+                    $.get('https://cmsapi.pulselive.com/rugby/team/' + e.teams[0].id).done(function(teamData) {
                         if (e.venue.country !== teamData.teams[0].country) {
                             if (e.teams[1]) {
                                 venueQueries++;
-                                $.get('//cmsapi.pulselive.com/rugby/team/' + e.teams[1].id).done(function(teamData) {
+                                $.get('https://cmsapi.pulselive.com/rugby/team/' + e.teams[1].id).done(function(teamData) {
                                     if (e.venue.country === teamData.teams[0].country) {
                                         // Saw this in the Pacific Nations Cup 2019 - a team was nominally Away
                                         // but in a home stadium. The seemed to get home nation advantage.


### PR DESCRIPTION
- include the "switched" flag alongside NHA and RWC
- make it more human readable: t(eams)XvY, s(core)P-Q, and f(lags)Z
- re-include matches that are already in the rankings, as the rankings we retrieve on page load appear to not include those matches[^1]
- switch the "is match home or away or switched" API calls to always https, like the rankings/teams calls

[^1]: the during-the-day rankings are likely not published at midnight; when we re-query rankings it does it by date, the date is midnight so it's before those rankings, and we get the previous rankings before those matches were applied