### PR TITLE
Bring long-running "tables" work back into main

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,10 +26,10 @@
             WRU
         </a>
         <a data-bind="css: source == '2171' ? 'sel' : '', attr: { href: $data.source == '2171' ? null : '?s=2171' }">
-            6N2024
+            M6N2024
         </a>
-        <a data-bind="css: source == '2192:WXV 1,2193:WXV 2,2194:WXV 3' ? 'sel' : '', attr: { href: $data.source == '2192:WXV 1,2193:WXV 2,2194:WXV 3' ? null : '?s=2192:WXV 1,2193:WXV 2,2194:WXV 3' }">
-            WXV2023
+        <a data-bind="css: source == '2175' ? 'sel' : '', attr: { href: $data.source == '2175' ? null : '?s=2175' }">
+            W6N2024
         </a>
     </div>
     <div id="leftright">

--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
                             <!-- ko if: triesMatter -->
                             <td class="details-center">Tries</td>
                             <!-- /ko -->
-                            <td class="details-center" colspan="4" data-bind="text: ($data.eventPhase && $data.liveScoreMode) ? ($data.eventPhase + ' (' + $data.liveScoreMode + ')') : ($data.eventPhase || $data.liveScoreMode), attr: { colspan: $data.triesMatter() ? 4 : 6 }"></td>
+                            <td class="details-center" colspan="4" data-bind="text: ($parent.multiplePools() && $data.eventPhase && $data.liveScoreMode) ? ($data.eventPhase + ' (' + $data.liveScoreMode + ')') : (($parent.multiplePools() && $data.eventPhase) || $data.liveScoreMode), attr: { colspan: $data.triesMatter() ? 4 : 6 }"></td>
                             <!-- ko if: triesMatter -->
                             <td class="details-center">Tries</td>
                             <!-- /ko -->

--- a/index.html
+++ b/index.html
@@ -95,16 +95,18 @@
                             <tr>
                                 <th></th>
                                 <th></th>
-                                <th class="right" title="points difference">PD</th>
-                                <th class="right" title="tries difference">TD</th title="points difference">
-                                <th class="right" title="points scored">PF</th title="points difference">
-                                <th class="right" title="tries scored">TF</th title="points scored">
+                                <th style="width: 12%" class="right" title="played">P</th>
+                                <th style="width: 12%" class="right" title="points difference">PD</th>
+                                <th style="width: 12%" class="right" title="tries difference">TD</th title="points difference">
+                                <th style="width: 12%" class="right" title="points scored">PF</th title="points difference">
+                                <th style="width: 12%" class="right" title="tries scored">TF</th title="points scored">
                             </tr>
                         </thead>
                         <tbody data-bind="foreach: table">
                             <tr>
                                 <th data-bind="text: name"></th>
                                 <td data-bind="text: pts"></td>
+                                <td><span data-bind="if: inProg">*</span><span data-bind="text: played"></span></td>
                                 <td data-bind="text: $data.pf - $data.pa"></td>
                                 <td data-bind="text: $data.tf - $data.ta"></td>
                                 <td data-bind="text: pf"></td>

--- a/index.html
+++ b/index.html
@@ -97,7 +97,9 @@
                                 <th></th>
                                 <th style="width: 9%" class="right" title="played">P</th>
                                 <th style="width: 9%" class="right" title="won">W</th>
+                                <!-- ko if: anyDraws -->
                                 <th style="width: 9%" class="right" title="drawn">D</th>
+                                <!-- /ko -->
                                 <th style="width: 9%" class="right" title="points difference">PD</th>
                                 <th style="width: 9%" class="right" title="tries difference">TD</th title="points difference">
                                 <th style="width: 9%" class="right" title="points scored">PF</th title="points difference">
@@ -110,7 +112,9 @@
                                 <td data-bind="text: pts"></td>
                                 <td data-bind="text: played"></td>
                                 <td data-bind="text: won"></td>
+                                <!-- ko if: $parent.anyDraws -->
                                 <td data-bind="text: drawn"></td>
+                                <!-- /ko -->
                                 <td data-bind="text: $data.pf - $data.pa"></td>
                                 <td data-bind="text: $data.tf - $data.ta"></td>
                                 <td data-bind="text: pf"></td>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 <script src="//cdn.rawgit.com/agschwender/jquery.formatDateTime/master/dist/jquery.formatDateTime.min.js"></script>
-<script src="//ajax.aspnetcdn.com/ajax/knockout/knockout-3.4.2.js"></script>
+<script src="//ajax.aspnetcdn.com/ajax/knockout/knockout-3.5.0.js"></script>
 <link href="//fonts.googleapis.com/css?family=Roboto:400,500" rel="stylesheet"> 
 <link href="styles/wr-calc.css?v={{site.time|date:'%s'}}" type="text/css" rel="stylesheet">
 <script src="scripts/models/ViewModel.js?v={{site.time|date:'%s'}}" type="text/javascript" ></script>
@@ -159,7 +159,7 @@
                             <!-- ko if: triesMatter -->
                             <td class="details-center">Tries</td>
                             <!-- /ko -->
-                            <td class="details-right" colspan="5" data-bind="text: venueNameAndCountry, title: venueCity"></td>
+                            <td class="details-right" colspan="5" data-bind="text: $data.venueNameAndCountry + ($data.switched() ? '*' : ''), title: $data.venueCity + ($data.switched() ? ' (home advantage to &quot;away&quot; team)' : '')"></td>
                         </tr>
                         <!-- /ko -->
                         <tr class="teams">
@@ -178,12 +178,11 @@
                                 <input type="number" min="0" data-bind="value: awayTries, disabled: alreadyInRankings" />
                             </td>
                             <!-- /ko -->
-                            <td colspan="2" style="text-align: right" data-bind="attr: { colspan: $data.triesMatter() ? 2 : 3 }">
+                            <td colspan="2" style="text-align: right" data-bind="attr: { colspan: $data.triesMatter() ? 2 : 3 }, class: $data.switched() ? 'switched' : ''">
                                 <select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: awayCaption, disabled: alreadyInRankings" style="width:100%"></select>
                             </td>
-                            <td>
+                            <td data-bind="class: $data.switched() ? 'switched' : ''">
                                 <input type="checkbox" data-bind="checked: noHome, disabled: alreadyInRankings" />
-                                <span data-bind="if: switched" title="Home team is nominally Away">*</span>
                             </td>
                             <!-- ko if: $parent.showIsRwc -->
                             <td><input type="checkbox" data-bind="checked: isRwc, disabled: alreadyInRankings" /></td>

--- a/index.html
+++ b/index.html
@@ -74,14 +74,26 @@
             <!-- ko if: pools -->
             <div id="leftBottom">
                 <div class="header">
-                    <h3>Tables</h3>
+                    <h3>Table<span data-bind="if: $data.pools().length > 1">s</span></h3>
                 </div>
+
+                <!-- ko if: $data.pools().length > 1 -->
+                <div id="whichPool">
+                    <!-- ko foreach: pools -->
+                    <label data-bind="css: $parent.poolChoice() === $data.pool ? 'sel' : ''">
+                        <input type="radio" name="pools" data-bind="checked: $parent.poolChoice, value: pool">
+                        <span data-bind="text: pool" />
+                    </label>
+                    <!-- /ko -->
+                </div>
+                <!-- /ko -->
+
                 <div id="tables">
                     <table id="poolstable">
-                        <!-- ko foreach: pools -->
+                        <!-- ko with: selectedPool -->
                         <thead>
                             <tr>
-                                <th>Pool <span data-bind="text: pool"></span></th>
+                                <th></th>
                                 <th></th>
                                 <th class="right" title="points difference">PD</th>
                                 <th class="right" title="tries difference">TD</th title="points difference">

--- a/index.html
+++ b/index.html
@@ -95,18 +95,22 @@
                             <tr>
                                 <th></th>
                                 <th></th>
-                                <th style="width: 12%" class="right" title="played">P</th>
-                                <th style="width: 12%" class="right" title="points difference">PD</th>
-                                <th style="width: 12%" class="right" title="tries difference">TD</th title="points difference">
-                                <th style="width: 12%" class="right" title="points scored">PF</th title="points difference">
-                                <th style="width: 12%" class="right" title="tries scored">TF</th title="points scored">
+                                <th style="width: 9%" class="right" title="played">P</th>
+                                <th style="width: 9%" class="right" title="won">W</th>
+                                <th style="width: 9%" class="right" title="drawn">D</th>
+                                <th style="width: 9%" class="right" title="points difference">PD</th>
+                                <th style="width: 9%" class="right" title="tries difference">TD</th title="points difference">
+                                <th style="width: 9%" class="right" title="points scored">PF</th title="points difference">
+                                <th style="width: 9%" class="right" title="tries scored">TF</th title="points scored">
                             </tr>
                         </thead>
                         <tbody data-bind="foreach: table">
-                            <tr>
+                            <tr data-bind="css: { inProg: inProg }">
                                 <th data-bind="text: name"></th>
                                 <td data-bind="text: pts"></td>
-                                <td><span data-bind="if: inProg">*</span><span data-bind="text: played"></span></td>
+                                <td data-bind="text: played"></td>
+                                <td data-bind="text: won"></td>
+                                <td data-bind="text: drawn"></td>
                                 <td data-bind="text: $data.pf - $data.pa"></td>
                                 <td data-bind="text: $data.tf - $data.ta"></td>
                                 <td data-bind="text: pf"></td>
@@ -235,9 +239,11 @@
                     </tfoot>
                 </table>
             </div>
+            <!-- ko ifnot: event -->
             <div id="addrow">
                 <button onclick='addFixture();'></button>
             </div>
+            <!-- /ko -->
         </div>
     </div>
     <div id="footer">

--- a/index.html
+++ b/index.html
@@ -95,9 +95,6 @@
                             <tr>
                                 <th></th>
                                 <th style="width: 9%" class="right" title="group points">Pts</th>
-                                <!-- ko if: anyTies -->
-                                <th style="width: 9%" class="right" title="group points vs. tied teams">PV</th>
-                                <!-- /ko -->
                                 <th style="width: 9%" class="right" title="played">Pl</th>
                                 <th style="width: 9%" class="right" title="won">W</th>
                                 <!-- ko if: anyDraws -->
@@ -113,9 +110,6 @@
                             <tr data-bind="css: { inProg: inProg }">
                                 <th data-bind="text: name"></th>
                                 <td data-bind="text: pts"></td>
-                                <!-- ko if: $parent.anyTies -->
-                                <td data-bind="text: pointsVsTies"></td>
-                                <!-- /ko -->
                                 <td data-bind="text: played"></td>
                                 <td data-bind="text: won"></td>
                                 <!-- ko if: $parent.anyDraws -->

--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
         <a data-bind="css: source == 'wru' ? 'sel' : '', attr: { href: $data.source == 'wru' ? null : '?s=wru' }">
             WRU
         </a>
-        <a data-bind="css: source == '1893' ? 'sel' : '', attr: { href: $data.source == '1893' ? null : '?s=1893' }">
-            RWC2023
+        <a data-bind="css: source == '2171' ? 'sel' : '', attr: { href: $data.source == '2171' ? null : '?s=2171' }">
+            6N2024
         </a>
         <a data-bind="css: source == '2192:WXV 1,2193:WXV 2,2194:WXV 3' ? 'sel' : '', attr: { href: $data.source == '2192:WXV 1,2193:WXV 2,2194:WXV 3' ? null : '?s=2192:WXV 1,2193:WXV 2,2194:WXV 3' }">
             WXV2023

--- a/index.html
+++ b/index.html
@@ -94,22 +94,28 @@
                         <thead>
                             <tr>
                                 <th></th>
-                                <th></th>
-                                <th style="width: 9%" class="right" title="played">P</th>
+                                <th style="width: 9%" class="right" title="group points">Pts</th>
+                                <!-- ko if: anyTies -->
+                                <th style="width: 9%" class="right" title="group points vs. tied teams">PV</th>
+                                <!-- /ko -->
+                                <th style="width: 9%" class="right" title="played">Pl</th>
                                 <th style="width: 9%" class="right" title="won">W</th>
                                 <!-- ko if: anyDraws -->
                                 <th style="width: 9%" class="right" title="drawn">D</th>
                                 <!-- /ko -->
                                 <th style="width: 9%" class="right" title="points difference">PD</th>
-                                <th style="width: 9%" class="right" title="tries difference">TD</th title="points difference">
-                                <th style="width: 9%" class="right" title="points scored">PF</th title="points difference">
-                                <th style="width: 9%" class="right" title="tries scored">TF</th title="points scored">
+                                <th style="width: 9%" class="right" title="tries difference">TD</th>
+                                <th style="width: 9%" class="right" title="points scored">PF</th>
+                                <th style="width: 9%" class="right" title="tries scored">TF</th>
                             </tr>
                         </thead>
                         <tbody data-bind="foreach: table">
                             <tr data-bind="css: { inProg: inProg }">
                                 <th data-bind="text: name"></th>
                                 <td data-bind="text: pts"></td>
+                                <!-- ko if: $parent.anyTies -->
+                                <td data-bind="text: pointsVsTies"></td>
+                                <!-- /ko -->
                                 <td data-bind="text: played"></td>
                                 <td data-bind="text: won"></td>
                                 <!-- ko if: $parent.anyDraws -->

--- a/index.html
+++ b/index.html
@@ -144,7 +144,13 @@
                         <!-- ko if: $data.venueNameAndCountry || $data.kickoff || $data.liveScoreMode || $data.eventPhase -->
                         <tr class="details">
                             <td class="details-left" colspan="2" data-bind="text: kickoff" title="Kickoff in your browser time"></td>
-                            <td class="details-center" colspan="6" data-bind="text: ($data.eventPhase && $data.liveScoreMode) ? ($data.eventPhase + ' (' + $data.liveScoreMode + ')') : ($data.eventPhase || $data.liveScoreMode)"></td>
+                            <!-- ko if: triesMatter -->
+                            <td class="details-center">Tries</td>
+                            <!-- /ko -->
+                            <td class="details-center" colspan="4" data-bind="text: ($data.eventPhase && $data.liveScoreMode) ? ($data.eventPhase + ' (' + $data.liveScoreMode + ')') : ($data.eventPhase || $data.liveScoreMode), attr: { colspan: $data.triesMatter() ? 4 : 6 }"></td>
+                            <!-- ko if: triesMatter -->
+                            <td class="details-center">Tries</td>
+                            <!-- /ko -->
                             <td class="details-right" colspan="5" data-bind="text: venueNameAndCountry, title: venueCity"></td>
                         </tr>
                         <!-- /ko -->

--- a/index.html
+++ b/index.html
@@ -31,44 +31,79 @@
     </div>
     <div id="leftright">
         <div id="left">
-            <div class="header">
-                <h3>Rankings</h3>
-            </div>
-            <div id="which" data-bind="if: rankingsChoice">
-                <label data-bind="css: $data.rankingsChoice() === 'original' ? 'sel' : ''">
-                    <input type="radio" name="rankings" value="original" data-bind="checked: rankingsChoice">
-                    <span data-bind="text: $data.originalDate() + ($data.originalDateIsEstimated() ? '*' : ''), title: $data.originalDateIsEstimated() ? 'Last published rankings on or before this date' : ''" />
-                </label>
-                <label data-bind="css: $data.rankingsChoice() === 'calculated' ? 'sel' : ''">
-                    <input type="radio" name="rankings" value="calculated" data-bind="checked: rankingsChoice">
-                    CALCULATED
-                </label>
-            </div>
+            <div id="leftTop">
+                <div class="header">
+                    <h3>Rankings</h3>
+                </div>
+                <div id="which" data-bind="if: rankingsChoice">
+                    <label data-bind="css: $data.rankingsChoice() === 'original' ? 'sel' : ''">
+                        <input type="radio" name="rankings" value="original" data-bind="checked: rankingsChoice">
+                        <span data-bind="text: $data.originalDate() + ($data.originalDateIsEstimated() ? '*' : ''), title: $data.originalDateIsEstimated() ? 'Last published rankings on or before this date' : ''" />
+                    </label>
+                    <label data-bind="css: $data.rankingsChoice() === 'calculated' ? 'sel' : ''">
+                        <input type="radio" name="rankings" value="calculated" data-bind="checked: rankingsChoice">
+                        CALCULATED
+                    </label>
+                </div>
 
-            <div id="rankings">
-                <!-- ko ifnot: rankingsChoice -->
-                <h4>
-                    Loading rankings from WR</a>
-                </h4>
-                <!-- /ko -->
+                <div id="rankings">
+                    <!-- ko ifnot: rankingsChoice -->
+                    <h4>
+                        Loading rankings from WR</a>
+                    </h4>
+                    <!-- /ko -->
 
-                <div data-bind="if: rankingsChoice">
-                    <table>
+                    <div data-bind="if: rankingsChoice">
+                        <table>
+                            <thead>
+                                <tr><th class="pos">#</th><th /><th class="name">Team</th><th colspan=2>Points</th></tr>
+                            </thead>
+                            <tbody data-bind="foreach: shownRankings">
+                                <tr data-bind="css: changeCls">
+                                    <td class="pos" data-bind="text: pos"></td>
+                                    <td class="posDiff" data-bind="html: previousPosDisplay"></td>
+                                    <td class="name" data-bind="text: team.displayName, title: team.displayTitle"></td>
+                                    <td data-bind="text: ptsDisplay"></td>
+                                    <td class="ptsDiff" data-bind="html: ptsDiffDisplay"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+            <!-- ko if: pools -->
+            <div id="leftBottom">
+                <div class="header">
+                    <h3>Tables</h3>
+                </div>
+                <div id="tables">
+                    <table id="poolstable">
+                        <!-- ko foreach: pools -->
                         <thead>
-                            <tr><th class="pos">#</th><th /><th class="name">Team</th><th colspan=2>Points</th></tr>
+                            <tr>
+                                <th>Pool <span data-bind="text: pool"></span></th>
+                                <th></th>
+                                <th class="right" title="points difference">PD</th>
+                                <th class="right" title="tries difference">TD</th title="points difference">
+                                <th class="right" title="points scored">PF</th title="points difference">
+                                <th class="right" title="tries scored">TF</th title="points scored">
+                            </tr>
                         </thead>
-                        <tbody data-bind="foreach: shownRankings">
-                            <tr data-bind="css: changeCls">
-                                <td class="pos" data-bind="text: pos"></td>
-                                <td class="posDiff" data-bind="html: previousPosDisplay"></td>
-                                <td class="name" data-bind="text: team.displayName, title: team.displayTitle"></td>
-                                <td data-bind="text: ptsDisplay"></td>
-                                <td class="ptsDiff" data-bind="html: ptsDiffDisplay"></td>
+                        <tbody data-bind="foreach: table">
+                            <tr>
+                                <th data-bind="text: name"></th>
+                                <td data-bind="text: pts"></td>
+                                <td data-bind="text: $data.pf - $data.pa"></td>
+                                <td data-bind="text: $data.tf - $data.ta"></td>
+                                <td data-bind="text: pf"></td>
+                                <td data-bind="text: tf"></td>
                             </tr>
                         </tbody>
+                        <!-- /ko -->
                     </table>
                 </div>
             </div>
+            <!-- /ko -->
         </div>
         <div id="right">
             <div class="header">
@@ -79,7 +114,7 @@
                     <thead>
                         <tr>
                             <th colspan="2">Home team</th>
-                            <th colspan="4">Score</th>
+                            <th colspan="6">Score</th>
                             <th colspan="2">Away team</th>
                             <th title='No Home Advantage'>NHA</th>
                             <th title='Is Rugby World Cup match'>RWC</th>
@@ -91,15 +126,29 @@
                         <!-- ko if: $data.venueNameAndCountry || $data.kickoff || $data.liveScoreMode || $data.eventPhase -->
                         <tr class="details">
                             <td class="details-left" colspan="2" data-bind="text: kickoff" title="Kickoff in your browser time"></td>
-                            <td class="details-center" colspan="4" data-bind="text: ($data.eventPhase && $data.liveScoreMode) ? ($data.eventPhase + ' (' + $data.liveScoreMode + ')') : ($data.eventPhase || $data.liveScoreMode)"></td>
+                            <td class="details-center" colspan="6" data-bind="text: ($data.eventPhase && $data.liveScoreMode) ? ($data.eventPhase + ' (' + $data.liveScoreMode + ')') : ($data.eventPhase || $data.liveScoreMode)"></td>
                             <td class="details-right" colspan="5" data-bind="text: venueNameAndCountry, title: venueCity"></td>
                         </tr>
                         <!-- /ko -->
                         <tr class="teams">
-                            <td colspan="2" style="text-align: left"><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: homeId, optionsCaption: homeCaption, disabled: alreadyInRankings"></select></td colspan="2">
+                            <td colspan="2" style="text-align: left" data-bind="attr: { colspan: $data.triesMatter() ? 2 : 3 }">
+                                <select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: homeId, optionsCaption: homeCaption, disabled: alreadyInRankings" style="width:100%"></select>
+                            </td>
+                            <!-- ko if: triesMatter -->
+                            <td>
+                                <input type="number" min="0" data-bind="value: homeTries, disabled: alreadyInRankings" />
+                            </td>
+                            <!-- /ko -->
                             <td colspan="2" style="text-align: right"><input type="number" min="0" data-bind="value: homeScore, disabled: alreadyInRankings" /></td colspan="2">
                             <td colspan="2" style="text-align: left"><input type="number" min="0" data-bind="value: awayScore, disabled: alreadyInRankings" /></td colspan="5">
-                            <td colspan="2" style="text-align: right"><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: awayCaption, disabled: alreadyInRankings"></select></td colspan="2">
+                            <!-- ko if: triesMatter -->
+                            <td>
+                                <input type="number" min="0" data-bind="value: awayTries, disabled: alreadyInRankings" />
+                            </td>
+                            <!-- /ko -->
+                            <td colspan="2" style="text-align: right" data-bind="attr: { colspan: $data.triesMatter() ? 2 : 3 }">
+                                <select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: awayCaption, disabled: alreadyInRankings" style="width:100%"></select>
+                            </td>
                             <td>
                                 <input type="checkbox" data-bind="checked: noHome, disabled: alreadyInRankings" />
                                 <span data-bind="if: switched" title="Home team is nominally Away">*</span>
@@ -109,19 +158,19 @@
                         </tr>
                         <!-- ko if: $data.hasValidTeams() && !$data.alreadyInRankings -->
                         <tr class="possible-changes">
-                            <td class="details-left" data-bind="text: $data.homeRankingBefore() ? $data.homeRankingBefore().toFixed(2) : ''"></td>
+                            <td colspan="2" class="details-left" data-bind="text: $data.homeRankingBefore() ? $data.homeRankingBefore().toFixed(2) : ''"></td colspan="2">
                             <td class="details-right" data-bind="text: $data.getDisplayChange(0), style: { 'text-decoration': $data.activeChange() == 0 ?  'underline' : 'inherit'}"></td class="details-center">
                             <td class="details-center" data-bind="text: $data.getDisplayChange(1), style: { 'text-decoration': $data.activeChange() == 1 ?  'underline' : 'inherit'}"></td class="details-center">
                             <td colspan="2" class="details-center" data-bind="text: $data.getDisplayChange(2), style: { 'text-decoration': $data.activeChange() == 2 ?  'underline' : 'inherit'}"></td class="details-center">
                             <td class="details-center" data-bind="text: $data.getDisplayChange(3), style: { 'text-decoration': $data.activeChange() == 3 ?  'underline' : 'inherit'}"></td class="details-center">
                             <td class="details-left" data-bind="text: $data.getDisplayChange(4), style: { 'text-decoration': $data.activeChange() == 4 ?  'underline' : 'inherit'}"></td class="details-center">
-                            <td class="details-right" data-bind="text: $data.awayRankingBefore() ? $data.awayRankingBefore().toFixed(2) : ''"></td>
+                            <td colspan="2" class="details-right" data-bind="text: $data.awayRankingBefore() ? $data.awayRankingBefore().toFixed(2) : ''"></td>
                             <td colspan="3"></td>
                         </tr>
                         <!-- /ko -->
                         <!-- ko if: alreadyInRankings -->
                         <tr class="possible-changes">
-                            <td colspan="8" class="details-center" title="The match is complete and kicked off 90 minutes or more before the latest rankings, so assume it is already included">Already ranked*</td>
+                            <td colspan="10" class="details-center" title="The match is complete and kicked off 90 minutes or more before the latest rankings, so assume it is already included">Already ranked*</td>
                             <td colspan="3"></td>
                         </tr>
                         <!-- /ko -->
@@ -137,6 +186,8 @@
                     -->
                     <tfoot aria-hidden="true">
                         <tr>
+                            <td></td>
+                            <td></td>
                             <td></td>
                             <td></td>
                             <td></td>

--- a/index.html
+++ b/index.html
@@ -130,9 +130,13 @@
                             <th colspan="2">Home team</th>
                             <th colspan="6">Score</th>
                             <th colspan="2">Away team</th>
-                            <th title='No Home Advantage'>NHA</th>
+                            <th title='"Home" team not at home'>NHA</th>
+                            <!-- ko if: showIsRwc -->
                             <th title='Is Rugby World Cup match'>RWC</th>
+                            <!-- /ko -->
+                            <!-- ko ifnot: event -->
                             <th></th>
+                            <!-- /ko -->
                     </tr>
                     </thead>
                     <!-- ko foreach: fixtures -->
@@ -167,8 +171,12 @@
                                 <input type="checkbox" data-bind="checked: noHome, disabled: alreadyInRankings" />
                                 <span data-bind="if: switched" title="Home team is nominally Away">*</span>
                             </td>
+                            <!-- ko if: $parent.showIsRwc -->
                             <td><input type="checkbox" data-bind="checked: isRwc, disabled: alreadyInRankings" /></td>
+                            <!-- /ko -->
+                            <!-- ko ifnot: $parent.event -->
                             <td><button data-bind="click: function () { $parent.fixtures.remove($data); }, disabled: alreadyInRankings">x</button></td>
+                            <!-- /ko -->
                         </tr>
                         <!-- ko if: $data.hasValidTeams() && !$data.alreadyInRankings -->
                         <tr class="possible-changes">
@@ -211,8 +219,12 @@
                             <td></td>
                             <td></td>
                             <td></td>
+                            <!-- ko if: showIsRwc -->
                             <td></td>
+                            <!-- /ko -->
+                            <!-- ko ifnot: event -->
                             <td></td>
+                            <!-- /ko -->
                         </tr>
                     </tfoot>
                 </table>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,9 @@
         <a data-bind="css: source == '1893' ? 'sel' : '', attr: { href: $data.source == '1893' ? null : '?s=1893' }">
             RWC2023
         </a>
+        <a data-bind="css: source == '2192:WXV 1,2193:WXV 2,2194:WXV 3' ? 'sel' : '', attr: { href: $data.source == '2192:WXV 1,2193:WXV 2,2194:WXV 3' ? null : '?s=2192:WXV 1,2193:WXV 2,2194:WXV 3' }">
+            WXV2023
+        </a>
     </div>
     <div id="leftright">
         <div id="left">

--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
                             <th colspan="2">Home team</th>
                             <th colspan="6">Score</th>
                             <th colspan="2">Away team</th>
-                            <th title='"Home" team not at home'>NHA</th>
+                            <th title='"Home" team not at home, or match after 2026-07-01'>NHA</th>
                             <!-- ko if: showIsRwc -->
                             <th title='Is Rugby World Cup match'>RWC</th>
                             <!-- /ko -->

--- a/index.html
+++ b/index.html
@@ -25,12 +25,15 @@
         <a data-bind="css: source == 'wru' ? 'sel' : '', attr: { href: $data.source == 'wru' ? null : '?s=wru' }">
             WRU
         </a>
-        <a data-bind="css: source == '2171' ? 'sel' : '', attr: { href: $data.source == '2171' ? null : '?s=2171' }">
-            M6N2024
-        </a>
-        <a data-bind="css: source == '2175' ? 'sel' : '', attr: { href: $data.source == '2175' ? null : '?s=2175' }">
-            W6N2024
-        </a>
+        <!-- ko ifnot: event -->
+        <span>
+            or pick
+            <select data-bind="options: events, optionsText: 'label', value: selectedEvent, optionsCaption: eventsCaption"></select>
+        </span>
+        <!-- /ko -->
+        <!-- ko if: eventName -->
+        <span class="sel" data-bind="text: eventName"></span>
+        <!-- /ko -->
     </div>
     <div id="leftright">
         <div id="left">

--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
                             <!-- ko if: triesMatter -->
                             <td class="details-center">Tries</td>
                             <!-- /ko -->
-                            <td class="details-right" colspan="5" data-bind="text: $data.venueNameAndCountry + ($data.switched() ? '*' : ''), title: $data.venueCity + ($data.switched() ? ' (home advantage to &quot;away&quot; team)' : '')"></td>
+                            <td class="details-right" colspan="5" data-bind="text: ($data.venueNameAndCountry || '') + ($data.switched() ? '*' : ''), title: ($data.venueCity || '') + ($data.switched() ? ' (home advantage to &quot;away&quot; team)' : '')"></td>
                         </tr>
                         <!-- /ko -->
                         <tr class="teams">

--- a/scripts/models/FixtureViewModel.js
+++ b/scripts/models/FixtureViewModel.js
@@ -25,6 +25,11 @@ var FixtureViewModel = function (parent) {
     this.switched = ko.observable();
     this.isRwc = ko.observable();
 
+    this.triesMatter = ko.observable();
+    this.pool = ko.observable();
+    this.homeTries = ko.observable();
+    this.awayTries = ko.observable();
+
     this.hasValidTeams = ko.computed(function () {
         var rankings = parent.rankingsById();
         var home = rankings[this.homeId()];

--- a/scripts/models/RankingViewModel.js
+++ b/scripts/models/RankingViewModel.js
@@ -23,11 +23,11 @@ var RankingViewModel = function (rawRanking) {
         var pos = this.pos();
         var previousPos = this.previousPos();
         if (pos < previousPos) {
-            return '(&uarr;' + previousPos + ')';
+            return '<span title="was ' + previousPos + '">(&uarr;' + (previousPos - pos) + ')</span>';
         } else if (pos > previousPos) {
-            return '(&darr;' + previousPos + ')';
+            return '<span title="was ' + previousPos + '">(&darr;' + (pos - previousPos) + ')</span>';
         } else {
-            return '<span style="visibility: hidden;" aria-hidden="true">(&rarr;' + previousPos + ')</span>';
+            return '<span style="visibility: hidden;" aria-hidden="true">(&rarr;' + 0 + ')</span>';
         }
     }, this);
 

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -311,6 +311,11 @@ var ViewModel = function (source) {
         if (!pools || !poolChoice || !pools.find(function (p) { return p.pool == poolChoice} )) return null;
         return pools.find(function (p) { return p.pool == poolChoice} );
     }, this);
+    
+    this.multiplePools = ko.computed(function () {
+        var pools = this.pools();
+        return pools && pools.length > 1;
+    }, this);
 
     // Whichever set of rankings is chosen.
     this.shownRankings = ko.computed(function () {

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -170,8 +170,8 @@ var ViewModel = function (source) {
             // parse ints here as sometimes we end up appending strings
             var homeScore = parseInt(fixture.homeScore());
             var awayScore = parseInt(fixture.awayScore());
-            var homeTries = parseInt(fixture.homeTries());
-            var awayTries = parseInt(fixture.awayTries());
+            var homeTries = parseInt(fixture.homeTries() || 0);
+            var awayTries = parseInt(fixture.awayTries() || 0);
 
             home.pf = home.pf + homeScore;
             away.pa = away.pa + homeScore;

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -122,6 +122,7 @@ var ViewModel = function (source) {
         }
     }, this);
 
+    this.poolChoice = ko.observable();
     this.pools = ko.computed(function() {
         if (this.source == 'mru' || this.source == 'wru') return null;
 
@@ -188,6 +189,10 @@ var ViewModel = function (source) {
             away.pv[fixture.homeId()] = awayTablePoints;
         });
 
+        if (!this.poolChoice()) {
+            this.poolChoice(Object.keys(pools).sort()[0]);
+        }
+
         return Object.keys(pools).sort().map(function (k) {
             return {
                 pool: k,
@@ -215,6 +220,13 @@ var ViewModel = function (source) {
                 })
             };
         });
+    }, this);
+
+    this.selectedPool = ko.computed(function () {
+        var pools = this.pools();
+        var poolChoice = this.poolChoice();
+        if (!pools || !poolChoice || !pools.find(function (p) { return p.pool == poolChoice} )) return null;
+        return pools.find(function (p) { return p.pool == poolChoice} );
     }, this);
 
     // Whichever set of rankings is chosen.

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -149,10 +149,11 @@ var ViewModel = function (source) {
             var awayId = fixture.awayId();
 
             // ensure the pools and teams exist
-            if (!pools[fixture.pool()]) {
-                pools[fixture.pool()] = {};
+            var poolKey = fixture.pool() || 'NO POOL';
+            if (!pools[poolKey]) {
+                pools[poolKey] = {};
             }
-            var pool = pools[fixture.pool()];
+            var pool = pools[poolKey];
 
             if (!pool[homeId]) {
                 pool[homeId] = { team: homeId, name: vm.rankingsById()[homeId].team.name, played: 0, pts: 0, pf: 0, pa: 0, tf: 0, ta: 0, pv: {}, inProg: false };
@@ -186,7 +187,7 @@ var ViewModel = function (source) {
             if (fixture.status == 'L1' || fixture.status == 'L2' || fixture.status == 'LHT') {
                 home.inProg = true;
                 away.inProg = true;
-                inProgPool = fixture.pool();
+                inProgPool = poolKey;
             }
 
             home.played = home.played + 1;
@@ -202,11 +203,18 @@ var ViewModel = function (source) {
             away.pv[homeId] = awayTablePoints;
         });
 
+        // remove "undefined" if it looks like "knockouts at a world cup" but not if it looks like "all matches in a round robin"
+        var poolKeys = Object.keys(pools);
+        if (poolKeys.length > 1) {
+            poolKeys = poolKeys.filter(function (k) { return k != 'NO POOL' });
+        }
+        poolKeys.sort();
+
         if (!this.poolChoice()) {
-            this.poolChoice(inProgPool || Object.keys(pools).sort()[0]);
+            this.poolChoice(inProgPool || poolKeys[0]);
         }
 
-        return Object.keys(pools).sort().map(function (k) {
+        return poolKeys.map(function (k) {
             return {
                 pool: k,
                 table: Object.values(pools[k]).sort(function (a, b) {

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -226,14 +226,23 @@ var ViewModel = function (source) {
         }
 
         function sortTeamsOnSameTablePoints(teams) {
+            // see if any teams have any points - if so we will set all to at least 0 to make visualisation easier, if not we will leave all blank
+            var anyPoints = false;
             for (var i = 0; i < teams.length; i++) {
-                teams[i].pointsVsTies = 0; // turn null to 0 if any have played
                 for (var j = 0; j < teams.length; j++) {
                     if (i == j) continue;
 
                     if (teams[i].pv[teams[j].team]) {
-                        teams[i].pointsVsTies += teams[i].pv[teams[j].team];
+                        anyPoints = true;
+                        teams[i].pointsVsTies = (teams[i].pointsVsTies || 0) + teams[i].pv[teams[j].team];
                     }
+                }
+            }
+
+            // if any teams have points, make sure the other teams show 0 rather than nothing (null)
+            if (anyPoints) {
+                for (var i = 0; i < teams.length; i++) {
+                    teams[i].pointsVsTies = teams[i].pointsVsTies || 0;
                 }
             }
 

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -138,6 +138,7 @@ var ViewModel = function (source) {
 
         // Apply each fixture in turn.
         var pools = {};
+        var inProgPool = null;
         $.each(fixtures, function (index, fixture) {
             // If the fixture doesn't have teams selected, or is already applied, do nothing.
             if (!fixture.hasValidTeams()) {
@@ -185,6 +186,7 @@ var ViewModel = function (source) {
             if (fixture.status == 'L1' || fixture.status == 'L2' || fixture.status == 'LHT') {
                 home.inProg = true;
                 away.inProg = true;
+                inProgPool = fixture.pool();
             }
 
             home.played = home.played + 1;
@@ -201,7 +203,7 @@ var ViewModel = function (source) {
         });
 
         if (!this.poolChoice()) {
-            this.poolChoice(Object.keys(pools).sort()[0]);
+            this.poolChoice(inProgPool || Object.keys(pools).sort()[0]);
         }
 
         return Object.keys(pools).sort().map(function (k) {

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -156,11 +156,11 @@ var ViewModel = function (source) {
             var pool = pools[poolKey];
 
             if (!pool[homeId]) {
-                pool[homeId] = { team: homeId, name: vm.rankingsById()[homeId].team.name, played: 0, pts: 0, pf: 0, pa: 0, tf: 0, ta: 0, pv: {}, inProg: false };
+                pool[homeId] = { team: homeId, name: vm.rankingsById()[homeId].team.name, played: 0, won: 0, drawn: 0, pts: 0, pf: 0, pa: 0, tf: 0, ta: 0, pv: {}, inProg: false };
             }
             var home = pool[homeId];
             if (!pool[awayId]) {
-                pool[awayId] = { team: awayId, name: vm.rankingsById()[awayId].team.name, played: 0, pts: 0, pf: 0, pa: 0, tf: 0, ta: 0, pv: {}, inProg: false };
+                pool[awayId] = { team: awayId, name: vm.rankingsById()[awayId].team.name, played: 0, won: 0, drawn: 0,pts: 0, pf: 0, pa: 0, tf: 0, ta: 0, pv: {}, inProg: false };
             }
             var away = pool[awayId];
 
@@ -198,6 +198,15 @@ var ViewModel = function (source) {
 
             var awayTablePoints = (homeScore < awayScore ? 4 : (homeScore == awayScore ? 2 : 0)) + (awayTries >= 4 ? 1 : 0) + ((homeScore > awayScore && homeScore <= awayScore + 7) ? 1 : 0);
             away.pts = away.pts + awayTablePoints;
+
+            if (homeScore > awayScore) {
+                home.won += 1;
+            } else if (homeScore < awayScore) {
+                away.won += 1;
+            } else {
+                home.drawn += 1;
+                away.drawn += 1;
+            }
 
             home.pv[awayId] = homeTablePoints;
             away.pv[homeId] = awayTablePoints;

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -1,6 +1,7 @@
 // Overall view model for the page
 var ViewModel = function (source) {
     this.source = source; // mru or wru or event id - doesn't really matter, just goes back into the query
+    this.event = ko.observable();
     this.rankingsSource = ko.observable(source); // in the footer link - should end up as mru or wru
 
     // The base rankings in an object, indexed by the ID of the team.
@@ -124,7 +125,7 @@ var ViewModel = function (source) {
 
     this.poolChoice = ko.observable();
     this.pools = ko.computed(function() {
-        if (this.source == 'mru' || this.source == 'wru') return null;
+        if (!this.event()) return null; // never pools for the normal rankings views
 
         var fixtures = this.deferredFixtures();
 
@@ -326,6 +327,8 @@ var ViewModel = function (source) {
         var usp = new URLSearchParams(params);
         return usp.toString();
     }, this);
+
+    this.showIsRwc = ko.observable(true);
 
     return this;
 };

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -218,6 +218,7 @@ var ViewModel = function (source) {
             return {
                 pool: k,
                 table: Object.values(pools[k]).sort(function (a, b) {
+                    // admittedly, this is for RWC2023, and might be different for other tournaments
                     var c1 = b.pts - a.pts;
                     if (c1) return c1;
 

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -104,8 +104,21 @@ var ViewModel = function (source) {
             sorted.push(r);
         });
         sorted.sort(function (a, b) { return b.pts() - a.pts(); });
+
+        var last = null;
         $.each(sorted, function (i, r) {
-            r.pos(i + 1);
+            if (last &&
+                last.previousPos() === r.previousPos() &&
+                last.previousPts() == last.pts() &&
+                r.previousPts() == r.pts()) {
+                // This was tied with the previous team before and neither have played so should remain so.
+                // If they played each other and tied this might still work.
+                // If they both played giants and got full 1/2/3 points it won't.
+                r.pos(last.pos());
+            } else {
+                r.pos(i + 1);
+            }
+            last = r;
         });
 
         // If we have calculated rankings, make sure we are showing the calculated ones.

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -413,7 +413,7 @@ var ViewModel = function (source) {
     this.showIsRwc = ko.observable(true);
 
     this.selectedEvent.subscribe(function (selectedEvent) {
-        window.location.replace('?s=' + selectedEvent.id);
+        window.location = '?s=' + selectedEvent.id;
     })
 
     return this;

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -158,6 +158,7 @@ var ViewModel = function (source) {
         var pools = {};
         var inProgPool = null;
         var noPool = 'NO POOL';
+        var usesThreeTryBp = !!/The Rugby Championship/.exec(this.eventName());
         $.each(fixtures, function (index, fixture) {
             // If the fixture doesn't have teams selected do nothing.
             if (!fixture.hasValidTeams()) {
@@ -212,10 +213,10 @@ var ViewModel = function (source) {
             home.played = home.played + 1;
             away.played = away.played + 1;
 
-            var homeTablePoints = (homeScore > awayScore ? 4 : (homeScore == awayScore ? 2 : 0)) + (homeTries >= 4 ? 1 : 0) + ((homeScore < awayScore && homeScore + 7 >= awayScore) ? 1 : 0);
+            var homeTablePoints = (homeScore > awayScore ? 4 : (homeScore == awayScore ? 2 : 0)) + ((usesThreeTryBp ? (homeTries - awayTries >= 3) : (homeTries >= 4)) ? 1 : 0) + ((homeScore < awayScore && homeScore + 7 >= awayScore) ? 1 : 0);
             home.pts = home.pts + homeTablePoints;
 
-            var awayTablePoints = (homeScore < awayScore ? 4 : (homeScore == awayScore ? 2 : 0)) + (awayTries >= 4 ? 1 : 0) + ((homeScore > awayScore && homeScore <= awayScore + 7) ? 1 : 0);
+            var awayTablePoints = (homeScore < awayScore ? 4 : (homeScore == awayScore ? 2 : 0)) + ((usesThreeTryBp ? (awayTries - homeTries >= 3) : (awayTries >= 4)) ? 1 : 0) + ((homeScore > awayScore && homeScore <= awayScore + 7) ? 1 : 0);
             away.pts = away.pts + awayTablePoints;
 
             if (homeScore > awayScore) {

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -2,6 +2,7 @@
 var ViewModel = function (source) {
     this.source = source; // mru or wru or event id - doesn't really matter, just goes back into the query
     this.event = ko.observable();
+    this.eventName = ko.observable();
     this.rankingsSource = ko.observable(source); // in the footer link - should end up as mru or wru
 
     // The base rankings in an object, indexed by the ID of the team.
@@ -21,6 +22,10 @@ var ViewModel = function (source) {
 
     // The fixtures used to calculate projected rankings.
     this.fixtures = ko.observableArray();
+
+    this.events = ko.observableArray();
+    this.eventsCaption = ko.observable('Event');
+    this.selectedEvent = ko.observable();
 
     // A rate-limited set of fixtures. This allows us to add fixtures performantly, by having the fixture list
     // bound to fixtures above but calculations based on this version.
@@ -406,6 +411,10 @@ var ViewModel = function (source) {
     }, this);
 
     this.showIsRwc = ko.observable(true);
+
+    this.selectedEvent.subscribe(function (selectedEvent) {
+        window.location.replace('?s=' + selectedEvent.id);
+    })
 
     return this;
 };

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -176,11 +176,11 @@ var ViewModel = function (source) {
             var pool = pools[poolKey];
 
             if (!pool.teams[homeId]) {
-                pool.teams[homeId] = { team: homeId, name: vm.rankingsById()[homeId].team.name, played: 0, won: 0, drawn: 0, pts: 0, pf: 0, pa: 0, tf: 0, ta: 0, beat: {}, inProg: false };
+                pool.teams[homeId] = { team: homeId, name: vm.rankingsById()[homeId].team.name, played: 0, won: 0, drawn: 0, pts: 0, pf: 0, pa: 0, tf: 0, ta: 0, ptsVs: {}, inProg: false };
             }
             var home = pool.teams[homeId];
             if (!pool.teams[awayId]) {
-                pool.teams[awayId] = { team: awayId, name: vm.rankingsById()[awayId].team.name, played: 0, won: 0, drawn: 0, pts: 0, pf: 0, pa: 0, tf: 0, ta: 0, beat: {}, inProg: false };
+                pool.teams[awayId] = { team: awayId, name: vm.rankingsById()[awayId].team.name, played: 0, won: 0, drawn: 0, pts: 0, pf: 0, pa: 0, tf: 0, ta: 0, ptsVs: {}, inProg: false };
             }
             var away = pool.teams[awayId];
 
@@ -215,16 +215,16 @@ var ViewModel = function (source) {
 
             var homeTablePoints = (homeScore > awayScore ? 4 : (homeScore == awayScore ? 2 : 0)) + ((usesThreeTryBp ? (homeTries - awayTries >= 3) : (homeTries >= 4)) ? 1 : 0) + ((homeScore < awayScore && homeScore + 7 >= awayScore) ? 1 : 0);
             home.pts = home.pts + homeTablePoints;
+            home.ptsVs[awayId] = (home.ptsVs[awayId] || 0) + homeTablePoints;
 
             var awayTablePoints = (homeScore < awayScore ? 4 : (homeScore == awayScore ? 2 : 0)) + ((usesThreeTryBp ? (awayTries - homeTries >= 3) : (awayTries >= 4)) ? 1 : 0) + ((homeScore > awayScore && homeScore <= awayScore + 7) ? 1 : 0);
             away.pts = away.pts + awayTablePoints;
+            away.ptsVs[homeId] = (away.ptsVs[homeId] || 0) + awayTablePoints;
 
             if (homeScore > awayScore) {
                 home.won += 1;
-                home.beat[awayId] = true;
             } else if (homeScore < awayScore) {
                 away.won += 1;
-                away.beat[homeId] = true;
             } else {
                 home.drawn += 1;
                 away.drawn += 1;
@@ -245,11 +245,14 @@ var ViewModel = function (source) {
 
         // admittedly, this is for RWC2023, and might be different for other tournaments
         function sortTeamsOnSameTablePoints(teams) {
-            // if there are only 2 teams, the winner of the match between them goes top
+            // if there are only 2 teams, the one with most vs table points between them goes top
             if (teams.length == 2) {
-                if (teams[0].beat[teams[1].team]) {
+                var pts0vs1 = teams[0].ptsVs[teams[1].team] || 0;
+                var pts1vs0 = teams[1].ptsVs[teams[0].team] || 0;
+
+                if (pts0vs1 > pts1vs0) {
                     return [teams[0], teams[1]];
-                } else if (teams[1].beat[teams[0].team]) {
+                } else if (pts1vs0 > pts0vs1) {
                     return [teams[1], teams[0]];
                 }
             }

--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -265,11 +265,11 @@ var fixturesLoaded = function (fixtures, rankings, event) {
             if (e.venue) {
                 fixture.venueNameAndCountry = [e.venue.name, e.venue.country].join(', ');
                 fixture.venueCity = e.venue.city;
-                queryTeam(e.teams[0].id).done(function(teamData) {
-                    if (e.venue.country !== teamData.country) {
+                queryTeam(e.teams[0].id).done(function(homeTeamData) {
+                    if (e.venue.country !== homeTeamData.country && !(e.venue.country == 'Northern Ireland' && homeTeamData.country == 'Ireland')) {
                         if (e.teams[1]) {
-                            queryTeam(e.teams[1].id).done(function(teamData) {
-                                if (e.venue.country === teamData.country) {
+                            queryTeam(e.teams[1].id).done(function(awayTeamData) {
+                                if (e.venue.country === awayTeamData.country && !(e.venue.country == 'Northern Ireland' && awayTeamData.country == 'Ireland')) {
                                     // Saw this in the Pacific Nations Cup 2019 - a team was nominally Away
                                     // but in a home stadium. They seemed to get home nation advantage.
                                     if (tournamentRespectsStadiumLocation) {

--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -179,7 +179,7 @@ var fixturesLoaded = function (fixtures, rankings, event) {
             // Covid-TRC (noticed in 2021 but apparently also in 2020) ignores the stadium location
             // and treats the nominal home team as always at home
             var tournamentRespectsStadiumLocation = !e.events.some(function (event) {
-                return event.label.match(/^202[01] Rugby Championship$/);
+                return event.label.match(/^The Rugby Championship 202[01]$/);
             });
 
             if (e.venue) {
@@ -227,7 +227,7 @@ var fixturesLoaded = function (fixtures, rankings, event) {
                     }
                 });
             }
-            fixture.isRwc((event && event.rankingsWeight == 2) || (e.events.length > 0 && e.events[0].rankingsWeight == 2) || (!!e.competition.match(/Rugby World Cup/)));
+            fixture.isRwc((event && event.rankingsWeight == 2) || (e.events.length > 0 && e.events[0].rankingsWeight == 2) || (!!e.competition.match(/Rugby World Cup/) && !e.competition.match(/Qualifying/)));
 
             if (event) {
                 function shortenPhase(name) {

--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -182,9 +182,15 @@ var fixturesLoaded = function (fixtures, rankings, event) {
     // if we're dealing with an event, also query to see if a team got a TBP?
     // in this case we ignore the counts about as we're going to disable the query string stuff anyway.
     function queryTries(id, cache) {
+        function getTriesForId(id) {
+            return $.get('https://api.wr-rims-prod.pulselive.com/rugby/v3/match/' + id + '/stats').then(function (stats) {
+                return [stats.teamStats[0].stats.Tries, stats.teamStats[1].stats.Tries];
+            });
+        }
+
         // In progress so neither query nor populate cache.
         if (!cache) {
-            return $.get('https://api.wr-rims-prod.pulselive.com/rugby/v3/match/' + id + '/stats');
+            return getTriesForId(id);
         }
 
         // Finished, so check cache, and populate if we load it.
@@ -192,9 +198,7 @@ var fixturesLoaded = function (fixtures, rankings, event) {
         if (localStorage[cacheKey]) {
             return $.when(JSON.parse(localStorage[cacheKey]));
         }
-        var promise = $.get('https://api.wr-rims-prod.pulselive.com/rugby/v3/match/' + id + '/stats').then(function (stats) {
-            return [stats.teamStats[0].stats.Tries, stats.teamStats[1].stats.Tries];
-        });
+        var promise = getTriesForId(id);
         if (cache) {
             promise.done(function (stats) {
                 localStorage[cacheKey] = JSON.stringify(stats);

--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -84,6 +84,7 @@ var loadRankings = function (rankingsSource, startDate, fixtures, event) {
 if (sourceString == 'mru' || sourceString == 'wru') {
     loadRankings(sourceString, dateString)
 } else {
+    viewModel.event(sourceString);
     // load the event!
     $.get('https://api.wr-rims-prod.pulselive.com/rugby/v3/event/' + sourceString + '/schedule?language=en').done(function (data) {
 
@@ -186,6 +187,8 @@ var fixturesLoaded = function (fixtures, rankings, event) {
     }
 
     // Parse each fixture into a view model, which adds it to the array.
+    var allRwc = true;
+    var allNotRwc = true;
     $.each(fixtures, function (i, e) {
         // I don't think we can reliably only request fixtures relevant to loaded teams, so filter here.
         // For knockouts where a team may not be decided yet, allow team to be null or id to be 0
@@ -255,7 +258,13 @@ var fixturesLoaded = function (fixtures, rankings, event) {
                     }
                 });
             }
-            fixture.isRwc((event && event.rankingsWeight == 2) || (e.events.length > 0 && e.events[0].rankingsWeight == 2) || (!!e.competition.match(/Rugby World Cup/)));
+            var isRwc = (event && event.rankingsWeight == 2) || (e.events.length > 0 && e.events[0].rankingsWeight == 2) || (!!e.competition.match(/Rugby World Cup/));
+            fixture.isRwc(isRwc);
+            if (isRwc) {
+                allNotRwc = false;
+            } else {
+                allRwc=  false;
+            }
 
             if (event) {
                 function shortenPhase(name) {
@@ -334,6 +343,10 @@ var fixturesLoaded = function (fixtures, rankings, event) {
             }
         });
     });
+
+    if ((allRwc || allNotRwc) && event) {
+        viewModel.showIsRwc(false);
+    }
 
     if (!anyQueries) {
         viewModel.queryString.subscribe(function (qs) {

--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -351,9 +351,13 @@ var fixturesLoaded = function (fixtures, rankings, event) {
             }
 
             if (event) {
-                if (e.eventPhaseId.type == 'Pool') {
-                    fixture.triesMatter(true); // also for e.g. 6 nations but worry about that later
-                    fixture.pool(e.eventPhaseId.subType);
+                // Tries matter if this is the "pool" stage of a large tournament, or
+                // (assume) if the tournament doesn't have more than one phase
+                if ((e.eventPhaseId && e.eventPhaseId.type == 'Pool') || !e.eventPhaseId) {
+                    fixture.triesMatter(true); 
+                    if (e.eventPhaseId) {
+                        fixture.pool(e.eventPhaseId.subType);
+                    }
                     if (e.status != 'U') {
                         queryTries(e.matchId, e.status == 'C').done(function (tries) {
                             fixture.homeTries(tries[0] || 0);

--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -280,6 +280,7 @@ var fixturesLoaded = function (fixtures, rankings, event) {
                 fixture.homeScore(e.scores[0]);
                 fixture.awayScore(e.scores[1]);
             }
+            fixture.status = e.status;
             switch (e.status) {
                 case 'U': {
                     // Try to detect if a match should have started by now, and just hasn't been reported by WR.

--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -181,6 +181,7 @@ if (sourceString == 'mru' || sourceString == 'wru') {
 // If we had up/down buttons we could maybe get rid of this.
 var addFixture = function (top, process) {
     var fixture = new FixtureViewModel(viewModel);
+    fixture.noHome(true);
     if (process) {
         process(fixture);
     }
@@ -288,6 +289,7 @@ var fixturesLoaded = function (fixtures, rankings, event) {
     // Parse each fixture into a view model, which adds it to the array.
     var allRwc = true;
     var allNotRwc = true;
+    var endOfHome = new Date(2026, 6, 1); // WR stopped applying home advantage.
     $.each(fixtures, function (i, e) {
         // I don't think we can reliably only request fixtures relevant to loaded teams, so filter here.
         
@@ -316,9 +318,12 @@ var fixturesLoaded = function (fixtures, rankings, event) {
         addFixture(true, function (fixture) {
             fixture.homeId(e.teams[0].id);
             if (e.teams[1]) fixture.awayId(e.teams[1].id); // See ANC above
-            fixture.noHome(false);
+
+            var kickoff = new Date(e.time.millis);
+            var afterEndOfHome = kickoff > endOfHome;
+            fixture.noHome(afterEndOfHome);
             fixture.switched(false);
-            fixture.kickoff = $.formatDateTime('D dd/mm/yy hh:ii', new Date(e.time.millis));
+            fixture.kickoff = $.formatDateTime('D dd/mm/yy hh:ii', kickoff);
 
             // Covid-TRC (noticed in 2021 but apparently also in 2020) ignores the stadium location
             // and treats the nominal home team as always at home

--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -288,6 +288,12 @@ var fixturesLoaded = function (fixtures, rankings, event) {
     var allNotRwc = true;
     $.each(fixtures, function (i, e) {
         // I don't think we can reliably only request fixtures relevant to loaded teams, so filter here.
+        
+        // If we're not querying an event, we're querying a sport; don't include fixtures that don't match
+        if (!event && e.sport.toUpperCase() != sourceString.toUpperCase()) {
+            return;
+        }
+
         // For knockouts where a team may not be decided yet, allow team to be null or id to be 0
         if ((e.teams[0] && (e.teams[0].id != '0') && !rankings[e.teams[0].id]) || (e.teams[1] && (e.teams[1].id != '0') && !rankings[e.teams[1].id])) {
             if (event) {

--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -81,8 +81,50 @@ var loadRankings = function (rankingsSource, startDate, fixtures, event) {
     });
 };
 
+
+// Format a date for the fixture or rankings API call.
+var formatDate = function(date) {
+    var d     = new Date(date),
+        month = '' + (d.getMonth() < 9 ? '0' : '') + (d.getMonth() + 1),
+        day   = '' + (d.getDate() < 10 ? '0' : '') + d.getDate(),
+        year  = d.getFullYear();
+
+    return [year, month, day].join('-');
+}
+
+var loadEvents = function(sport) {
+    viewModel.eventsCaption(sport.toUpperCase() + ' Event');
+    var start = new Date(new Date(new Date().getFullYear(), 0, 1));
+    var end = new Date(new Date(new Date().getFullYear(), 12, 13));
+    $.get('https://api.wr-rims-prod.pulselive.com/rugby/v3/event/?startDate=' + formatDate(start) + '&endDate=' + formatDate(end) + '&sport=' + sport + '&pageSize=50').done(function (data) {
+        var events = [];
+        for (var i = 0; i < data.content.length; i++) {
+            var event = data.content[i];
+
+            // Don't show the whole year
+            if (event.label.match(/^\d{4} .*en's International$/)) continue;
+
+            // Collect WXV
+            if (event.label.match(/^WXV/)) {
+                var id = event.id + ':' + event.label;
+                var label = event.label;
+                while (i + 1 < data.content.length && data.content[i + 1].label.match(/^WXV/)) {
+                    i++;
+                    id += "," + data.content[i].id + ':' + data.content[i].label;
+                    label += '/' + data.content[i].label;
+                }
+                events.push({ id: id, label: label });
+            } else {
+                events.push({ id: event.id, label: event.label });
+            }
+        }
+        viewModel.events(events);
+    })
+}
+
 if (sourceString == 'mru' || sourceString == 'wru') {
     loadRankings(sourceString, dateString)
+    loadEvents(sourceString)
 } else {
     viewModel.event(sourceString);
     // load the event(s)!
@@ -94,6 +136,7 @@ if (sourceString == 'mru' || sourceString == 'wru') {
         $.get('https://api.wr-rims-prod.pulselive.com/rugby/v3/event/' + sourceString + '/schedule?language=en').done(function (data) {
 
             var events = {};
+            viewModel.eventName(data.event.label);
             events[data.event.id] = { event: data.event };
             loadRankings(
                 data.event.sport,
@@ -103,8 +146,9 @@ if (sourceString == 'mru' || sourceString == 'wru') {
             );
         });
     } else {
-        // Load all the events, and aggregate them into one big colelction of matches.
+        // Load all the events, and aggregate them into one big collection of matches.
         var eventNames = sourceString.split(',').map(function (idAndName) { return idAndName.split(':')[1]; });
+        viewModel.eventName(eventNames.join('/'));
         var promises = eventIds.map(function (eventId) {
             return $.get('https://api.wr-rims-prod.pulselive.com/rugby/v3/event/' + eventId + '/schedule?language=en');
         });
@@ -246,6 +290,9 @@ var fixturesLoaded = function (fixtures, rankings, event) {
         // I don't think we can reliably only request fixtures relevant to loaded teams, so filter here.
         // For knockouts where a team may not be decided yet, allow team to be null or id to be 0
         if ((e.teams[0] && (e.teams[0].id != '0') && !rankings[e.teams[0].id]) || (e.teams[1] && (e.teams[1].id != '0') && !rankings[e.teams[1].id])) {
+            if (event) {
+                console.warn('Not including fixture ' + e.teams[0].name + ' vs ' + e.teams[1].name + ' as a team is missing from the rankings');
+            }
             return;
         };
 
@@ -403,16 +450,6 @@ var fixturesLoaded = function (fixtures, rankings, event) {
         viewModel.showIsRwc(false);
     }
 };
-
-// Format a date for the fixture or rankings API call.
-var formatDate = function(date) {
-    var d     = new Date(date),
-        month = '' + (d.getMonth() < 9 ? '0' : '') + (d.getMonth() + 1),
-        day   = '' + (d.getDate() < 10 ? '0' : '') + d.getDate(),
-        year  = d.getFullYear();
-
-    return [year, month, day].join('-');
-}
 
 // Add days to a date.
 Date.prototype.addDays = function (d) {

--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -137,6 +137,7 @@ if (sourceString == 'mru' || sourceString == 'wru') {
 
             var events = {};
             viewModel.eventName(data.event.label);
+            document.title = 'WRRC - ' + data.event.label;
             events[data.event.id] = { event: data.event };
             loadRankings(
                 data.event.sport,
@@ -149,6 +150,7 @@ if (sourceString == 'mru' || sourceString == 'wru') {
         // Load all the events, and aggregate them into one big collection of matches.
         var eventNames = sourceString.split(',').map(function (idAndName) { return idAndName.split(':')[1]; });
         viewModel.eventName(eventNames.join('/'));
+        document.title = 'WRRC - ' + eventNames.join('/');
         var promises = eventIds.map(function (eventId) {
             return $.get('https://api.wr-rims-prod.pulselive.com/rugby/v3/event/' + eventId + '/schedule?language=en');
         });

--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -294,13 +294,22 @@ var fixturesLoaded = function (fixtures, rankings, event) {
             return;
         }
 
-        // For knockouts where a team may not be decided yet, allow team to be null or id to be 0
-        if ((e.teams[0] && (e.teams[0].id != '0') && !rankings[e.teams[0].id]) || (e.teams[1] && (e.teams[1].id != '0') && !rankings[e.teams[1].id])) {
-            if (event) {
-                console.warn('Not including fixture ' + e.teams[0].name + ' vs ' + e.teams[1].name + ' as a team is missing from the rankings');
-            }
-            return;
-        };
+        if (event) {
+            // For knockouts where a team may not be decided yet, allow team to be null or id to be 0
+            if ((e.teams[0] && (e.teams[0].id != '0') && !rankings[e.teams[0].id]) || (e.teams[1] && (e.teams[1].id != '0') && !rankings[e.teams[1].id])) {
+                if (event) {
+                    console.warn('Not including fixture ' + e.teams[0].name + ' vs ' + e.teams[1].name + ' as a team is missing from the rankings');
+                }
+                return;
+            };
+        } else {
+            // If we're not looking at an event, don't include such matches.
+            // People might have to insert a row for an upcoming final.
+            // But we were getting matches for non-International tournaments and no easy way to tell that is the case.
+            if (!e.teams[0] || !rankings[e.teams[0].id] || !e.teams[1] || !rankings[e.teams[1].id]) {
+                return;
+            };
+        }
 
         addFixture(true, function (fixture) {
             fixture.homeId(e.teams[0].id);

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -162,6 +162,12 @@ table {
         display: flex;
         flex-direction: column;
     }
+    #leftTop, #leftBottom {
+        @include height(6);
+        flex: 0.5;
+        display: flex;
+        flex-direction: column;
+    }
     #right {
         @include height(0);
         height: 100%;
@@ -170,15 +176,21 @@ table {
         flex: 1;
     }
     #left, #right {
-    .header h3 {
+        .header h3 {
             flex: 0;
         }
     }
     #which,#union {
         flex-shrink: 0;
     }
-    #rankings {
+    #leftTop, #leftBottom {
         flex: 1;
+        flex-shrink: 1;
+        overflow-y: hidden;
+    }
+    #rankings, #tables {
+        flex: 1;
+        flex-shrink: 1;
         overflow-y: scroll;
     }
     #fixtures {
@@ -194,7 +206,15 @@ table {
         display: flex;
         flex-direction: column-reverse;
     }
-    #left, #right {
+    #left {
+        display: flex;
+        flex-direction: column-reverse;
+    }
+    #right {
+        display: flex;
+        flex-direction: column;
+    }
+    #leftTop, #leftBottom {
         display: flex;
         flex-direction: column;
     }
@@ -396,5 +416,18 @@ body {
         background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYAQMAAADaua+7AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAZdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuMTM0A1t6AAAABlBMVEX///////9VfPVsAAAAAXRSTlMAQObYZgAAABZJREFUCNdjYLBhYCAG////HwUTqQ8AH00QpSze/owAAAAASUVORK5CYII=');
         background-repeat: no-repeat;
         background-position: 50% 50%;
+    }
+}
+
+#poolstable {
+    th {
+        text-align: left;
+    }
+    th.right {
+        text-align: right;
+    }
+
+    td {
+        text-align: right;
     }
 }

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -164,7 +164,6 @@ table {
     }
     #leftTop, #leftBottom {
         @include height(6);
-        flex: 0.5;
         display: flex;
         flex-direction: column;
     }
@@ -189,15 +188,16 @@ table {
         overflow-y: hidden;
     }
     #leftBottom {
+        flex-shrink: 0;
         overflow-y: hidden;
     }
-    #rankings, #tables {
-        flex: 1;
-        flex-shrink: 1;
+    #tables {
+        overflow-y: hidden;
+    }
+    #rankings {
         overflow-y: scroll;
     }
     #fixtures {
-        flex: 1;
         overflow-y: scroll;
     }
     #addrow {
@@ -427,6 +427,11 @@ body {
 }
 #poolstable {
     width: 100%;
+
+    tr.inProg {
+        font-style: italic;
+    }
+
     th {
         text-align: left;
     }

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -104,7 +104,7 @@ table {
         }
     }
 }
-#which, #union {
+#which, #union, #whichPool {
     font-size: 14px;
     font-weight: 500;
 }
@@ -180,12 +180,15 @@ table {
             flex: 0;
         }
     }
-    #which,#union {
+    #which,#union,#whichPool {
         flex-shrink: 0;
     }
-    #leftTop, #leftBottom {
+    #leftTop {
         flex: 1;
         flex-shrink: 1;
+        overflow-y: hidden;
+    }
+    #leftBottom {
         overflow-y: hidden;
     }
     #rankings, #tables {
@@ -248,7 +251,7 @@ body {
     }
 }
 
-#which {
+#which,#whichPool {
     display: flex;
     @extend %primary;
 
@@ -419,7 +422,11 @@ body {
     }
 }
 
+#tables {
+    padding: 5px;
+}
 #poolstable {
+    width: 100%;
     th {
         text-align: left;
     }

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -386,6 +386,10 @@ body {
         input[type=number] {
             width: 3em;
         }
+
+        td.switched {
+            background-color: #ddd;
+        }
     }
 }
 

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -285,7 +285,7 @@ body {
     line-height: 24px;
     width: 100%;
 
-    a {
+    a, span {
         flex-grow: 1;
         text-align: center;
         border-bottom: 2px solid $white;
@@ -299,6 +299,10 @@ body {
         &:not(.sel) {
             @extend .secondaryText;
         }
+    }
+
+    select {
+        flex-grow: 1;
     }
 }
 


### PR DESCRIPTION
Expands "event" mode with best effort to show table/pools
(so when you're doing hypothetical pool stage results, you can
then see who to use for hypothetical knockout stage results)

This means capturing number of tries, not just score, and knowing
how that translates into bonus points.

I don't go so far as to follow different tournaments' tie-break
rules, just one best guess.

Also brings in the July 2026 removal of home advantage.